### PR TITLE
fix: the Return type

### DIFF
--- a/src/react-cool-onclickoutside.d.ts
+++ b/src/react-cool-onclickoutside.d.ts
@@ -14,7 +14,7 @@ declare module "react-cool-onclickoutside" {
   }
 
   interface Return {
-    (element: HTMLElement): void;
+    (element: HTMLElement | null): void;
   }
 
   const useOnclickOutside: (callback: Callback, options?: Options) => Return;


### PR DESCRIPTION
## What

Resolves #300

## Why

The `ref` property has this definition:
```typescript
ref?: ((instance: HTMLElement | null) => void) | React.RefObject<HTMLElement> | null | undefined
```
And the `Return` type is incompatible with it.

## Checklist

- [ ] Documentation added N/A
- [ ] Tests N/A
- [x] Typescript definitions updated
- [x] Ready to be merged
